### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [
-    "lib", "bin"
+    "lib",
+    "bin"
   ],
   "scripts": {
     "build": "npm run clean && npm run compile",
@@ -27,9 +28,9 @@
     "microsoft"
   ],
   "dependencies": {
-    "node-uuid": "^1.4.7",
     "request": "^2.75.0",
-    "request-promise-native": "^1.0.3"
+    "request-promise-native": "^1.0.3",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.33",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as util from 'util';
-import * as uuid from 'node-uuid';
+import * as uuid from 'uuid';
 
 import { VoiceRecognitionResponse, VoiceSynthesisResponse } from './models';
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.